### PR TITLE
Small build cleanups

### DIFF
--- a/builds/Resources/mkBuild_Dir.py
+++ b/builds/Resources/mkBuild_Dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2018-2020 Bluespec, Inc.
 # See LICENSE for license details

--- a/src_Testbench/Top/C_Imported_Functions.c
+++ b/src_Testbench/Top/C_Imported_Functions.c
@@ -33,6 +33,7 @@
 #include <sys/socket.h>       //  socket definitions
 #include <sys/types.h>        //  socket types
 #include <arpa/inet.h>        //  inet (3) funtions
+#include <netinet/in.h>
 #include <fcntl.h>            // To set non-blocking mode
 
 // ================================================================


### PR DESCRIPTION
Fix an include so that we get the `INADDR_ANY` macro from a portable location, don't hard-code the location of python3.